### PR TITLE
Remove "null" folder in topo_drag

### DIFF
--- a/exp/path_names
+++ b/exp/path_names
@@ -163,7 +163,7 @@ atmos_param/shallow_conv/null/shallow_conv.f90
 atmos_param/shallow_conv/shallow_conv.f90
 atmos_param/stable_bl_turb/stable_bl_turb.f90
 atmos_param/strat_cloud/strat_cloud.f90
-atmos_param/topo_drag/null/topo_drag.f90
+atmos_param/topo_drag/topo_drag.f90
 atmos_param/vert_diff_driver/vert_diff_driver.f90
 atmos_param/vert_diff/vert_diff.f90
 atmos_param/vert_turb_driver/vert_turb_driver.f90

--- a/src/atmos_param/topo_drag/topo_drag.f90
+++ b/src/atmos_param/topo_drag/topo_drag.f90
@@ -8,7 +8,7 @@ module topo_drag_mod
 !  Calculates horizontal velocity tendency due to topographic drag
 !--------------------------------------------------------------------------
 
-  use       Fms_Mod, only: FILE_EXIST, OPEN_NAMELIST_FILE, ERROR_MESG, FATAL, &
+  use       fms_mod, only: FILE_EXIST, OPEN_NAMELIST_FILE, ERROR_MESG, FATAL, &
                            READ_DATA, WRITE_DATA, CLOSE_FILE, mpp_pe, mpp_root_pe, &
                            write_version_number, stdlog
   use Constants_Mod, only: Grav,Cp_Air,Rdgas,Radius,Pi,Radian


### PR DESCRIPTION
Current module is nested within a folder called `NULL`. Remove this bizarre name convention and just call it `topo_drag/topo_drag.f90` like all other modules.